### PR TITLE
Avoid triggering the commands of other bots through url titles

### DIFF
--- a/url.py
+++ b/url.py
@@ -352,5 +352,10 @@ def main(i, irc):
         if not title:
             continue
 
+        # Add invisible padding at start to avoid
+        # triggering the command of another irc bot
+        # Two bold formating chars cancel each other
+        title = f"\x02\x02{text}"
+
         irc.privmsg(i.channel, title)
         prev_u.add(u)


### PR DESCRIPTION
drastikbot can execute commands on other bots using the title of a url. This could cause issues particularly if a BotServ bot is in the channel and drastikbot has OP.

This change fixes this by pretending two bold indicator chars that should be hidden by most IRC clients at the beginning of the title string.